### PR TITLE
Saml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Install libxmlsec1
+        run: sudo apt-get install -y libxmlsec1-dev
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip pipenv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.pytest_cache
+*.pem
+

--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,1 @@
+libxmlsec1-dev

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 flask = "*"
 gunicorn = "*"
+python3-saml = "*"
 
 [dev-packages]
 python-dotenv = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "86848acf8d800d259af92d85b5503e3d722e4e7e7fbcdb5d347e46b761597493"
+            "sha256": "448244710cbf3ea9a3390ba7d53a68f47266c503d8035f4fc683338271bae921"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -24,6 +24,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==8.0.1"
         },
+        "defusedxml": {
+            "hashes": [
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.6.0"
+        },
         "flask": {
             "hashes": [
                 "sha256:1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55",
@@ -40,6 +48,13 @@
             "index": "pypi",
             "version": "==20.1.0"
         },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
+        },
         "itsdangerous": {
             "hashes": [
                 "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
@@ -55,6 +70,58 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.0.1"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:079f3ae844f38982d156efce585bc540c16a926d4436712cf4baee0cce487a3d",
+                "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3",
+                "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2",
+                "sha256:1b38116b6e628118dea5b2186ee6820ab138dbb1e24a13e478490c7db2f326ae",
+                "sha256:1b7584d421d254ab86d4f0b13ec662a9014397678a7c4265a02a6d7c2b18a75f",
+                "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927",
+                "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3",
+                "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7",
+                "sha256:3082c518be8e97324390614dacd041bb1358c882d77108ca1957ba47738d9d59",
+                "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f",
+                "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade",
+                "sha256:36108c73739985979bf302006527cf8a20515ce444ba916281d1c43938b8bb96",
+                "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468",
+                "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b",
+                "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4",
+                "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354",
+                "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83",
+                "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04",
+                "sha256:5c8c163396cc0df3fd151b927e74f6e4acd67160d6c33304e805b84293351d16",
+                "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791",
+                "sha256:6f12e1427285008fd32a6025e38e977d44d6382cf28e7201ed10d6c1698d2a9a",
+                "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51",
+                "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1",
+                "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a",
+                "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f",
+                "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee",
+                "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec",
+                "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969",
+                "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28",
+                "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a",
+                "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa",
+                "sha256:bc4313cbeb0e7a416a488d72f9680fffffc645f8a838bd2193809881c67dd106",
+                "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d",
+                "sha256:c47ff7e0a36d4efac9fd692cfa33fbd0636674c102e9e8d9b26e1b93a94e7617",
+                "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4",
+                "sha256:cdaf11d2bd275bf391b5308f86731e5194a21af45fbaaaf1d9e8147b9160ea92",
+                "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0",
+                "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4",
+                "sha256:d916d31fd85b2f78c76400d625076d9124de3e4bda8b016d25a050cc7d603f24",
+                "sha256:df7c53783a46febb0e70f6b05df2ba104610f2fb0d27023409734a3ecbb78fb2",
+                "sha256:e1cbd3f19a61e27e011e02f9600837b921ac661f0c40560eefb366e4e4fb275e",
+                "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0",
+                "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654",
+                "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2",
+                "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23",
+                "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.6.3"
         },
         "markupsafe": {
             "hashes": [
@@ -96,6 +163,23 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
         },
+        "python3-saml": {
+            "hashes": [
+                "sha256:336ef44f894b5e09cf339a67b007d8299096b7b44f43ee7426eae410771e4466",
+                "sha256:5e04d586fa7c6017ae4e00d16769d4ff04ba0b9903a2d1c1e61b6ad9e9ff23fe",
+                "sha256:cbbea3e38a020a93fe745f59c6969bb1c60e726a49d34bbab76d03dc2bbe2a66"
+            ],
+            "index": "pypi",
+            "version": "==1.10.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "werkzeug": {
             "hashes": [
                 "sha256:1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42",
@@ -103,6 +187,23 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
+        },
+        "xmlsec": {
+            "hashes": [
+                "sha256:23f209260b37bdc2fd96af837494c47dd1e67964f077442b63acd83c0f62e212",
+                "sha256:4fb38ab0bf3e47cbae136119674a869e09d61c939b510350f369c8ac46087373",
+                "sha256:705ab5b848afdf3a5c78b1322276054c885f44dc51601e14cb883a9c86cbe20f",
+                "sha256:843d10bba4c480609da74ee11fff1ee0fc1c12821c656979f12a7a4ecb043e03",
+                "sha256:86d54b93f8278e2f0c504d0744e39a483c1c7ce9993f2ca70184cc7770faa982",
+                "sha256:8922fba55a060ee81de4a7f5efc593c5bf121047763aecf0eead02e061c9d2db",
+                "sha256:c7b49d4fce83186b89f7ce6cec765245d36a70d0acc2f3ed0ba95c735b3667da",
+                "sha256:cd2eaaff7f31784a07dd99ce81fa767313df3ba1834faa4143ee2c07000cac7a",
+                "sha256:dea5bef9b5830c36ccb7a68a0d94d49eaea4d03fbbd04179652bf661b7e6e30f",
+                "sha256:eadff662d89c80db409c69d82eb3e695e16d4a5e8ab56b5b22670a54e9c6ff20",
+                "sha256:ee233d0bc27fb8f447ca2622b0de2ac2df45b8795f02ef263825912011fe4fe9"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.3.11"
         }
     },
     "develop": {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# bd_auth
+
+## Local development
+
+- `python3-saml` package requires `libxmlsec1`.
+  Suggest `brew install libxmlsec1` on macOS
+- possibly also needs `pkg-config` (not sure)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,16 @@
 - `python3-saml` package requires `libxmlsec1`.
   Suggest `brew install libxmlsec1` on macOS
 - possibly also needs `pkg-config` (not sure)
+
+## Required ENV in production
+
+`FLASK_APP` = bdauth
+`FLASK_ENV` = production
+`IDP_CERT` = standard IST IDP setting
+`IDP_ENTITY_ID` = standard IST IDP setting
+`IDP_SSO_URL` = standard IST IDP setting
+`SECRET_KEY` = generate a long random string. Used for session security
+`SP_ACS_URL` = route in this app that handles the response from IDP
+`SP_CERT` = obtained from self signed cert generated for this app
+`SP_ENTITY_ID` = domain name of app + /saml
+`SP_KEY` = obtained from self signed key generated for this app

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "bdauth",
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-apt"
+    },
+    {
+      "url": "heroku/python"
+    }
+  ]
+}

--- a/bdauth/__init__.py
+++ b/bdauth/__init__.py
@@ -3,7 +3,12 @@ import os
 
 from flask import Flask
 
+from bdauth import auth, debug
+from bdauth.auth import login_required
+
 app = Flask(__name__, instance_relative_config=True)
+app.register_blueprint(auth.bp)
+app.register_blueprint(debug.bp)
 
 flask_env = os.getenv('FLASK_ENV')
 

--- a/bdauth/auth.py
+++ b/bdauth/auth.py
@@ -1,0 +1,103 @@
+import json
+import os
+from functools import wraps
+from urllib.parse import urljoin, urlparse
+
+from flask import (
+    Blueprint, current_app, make_response, redirect, request, session, url_for
+)
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+
+
+def is_safe_url(target):
+    ref_url = urlparse(request.host_url)
+    test_url = urlparse(urljoin(request.host_url, target))
+    return test_url.scheme in ('http', 'https') and \
+        ref_url.netloc == test_url.netloc
+
+
+def load_saml_settings():
+    json_settings = {}
+    with open("saml/settings.json", 'r') as json_file:
+        json_settings = json.load(json_file)
+        json_settings['debug'] = current_app.config['DEBUG']
+        json_settings['sp']['entityId'] = os.getenv('SP_ENTITY_ID')
+        json_settings['sp']['assertionConsumerService']['url'] = \
+            os.getenv('SP_ACS_URL')
+        json_settings['sp']['x509cert'] = os.getenv('SP_CERT')
+        json_settings['sp']['privateKey'] = os.getenv('SP_KEY')
+        json_settings['idp']['entityId'] = os.getenv('IDP_ENTITY_ID')
+        json_settings['idp']['singleSignOnService']['url'] = \
+            os.getenv('IDP_SSO_URL')
+        json_settings['idp']['x509cert'] = os.getenv('IDP_CERT')
+    return json_settings
+
+
+def login_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if (current_app.config['ENV'] != 'development' and
+                'samlSessionIndex' not in session):
+            return redirect(url_for('auth.saml', sso=True, next=request.url))
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+def prepare_flask_request(request):
+    url_data = urlparse(request.url)
+    return {
+        'https': 'on' if request.scheme == 'https' else 'off',
+        'http_host': request.host,
+        'server_port': url_data.port,
+        'script_name': request.path,
+        'get_data': request.args.copy(),
+        'post_data': request.form.copy()
+    }
+
+
+bp = Blueprint('auth', __name__, url_prefix='/saml')
+
+
+@bp.route('/', methods=('GET', 'POST'))
+def saml():
+    saml_settings = load_saml_settings()
+    req = prepare_flask_request(request)
+    auth = OneLogin_Saml2_Auth(req, saml_settings)
+    errors = []
+    next_page = request.args.get('next')
+    if not next_page or is_safe_url(next_page) is False:
+        next_page = ''
+
+    if 'sso' in request.args:
+        return redirect(auth.login(return_to=next_page))
+
+    elif 'acs' in request.args:
+        auth.process_response()
+        errors = auth.get_errors()
+        if not auth.is_authenticated():
+            # TODO: return something helpful to the user
+            pass
+        if len(errors) == 0:
+            session['samlNameId'] = auth.get_nameid()
+            session['samlSessionIndex'] = auth.get_session_index()
+            return redirect(request.form['RelayState'])
+        else:
+            print('Errors: %s', errors)
+            print('Last error reason: %s', auth.get_last_error_reason())
+
+
+@bp.route('/metadata/')
+def metadata():
+    saml_settings = load_saml_settings()
+    req = prepare_flask_request(request)
+    auth = OneLogin_Saml2_Auth(req, saml_settings)
+    settings = auth.get_settings()
+    metadata = settings.get_sp_metadata()
+    errors = settings.validate_metadata(metadata)
+
+    if len(errors) == 0:
+        resp = make_response(metadata, 200)
+        resp.headers['Content-Type'] = 'text/xml'
+    else:
+        resp = make_response(', '.join(errors), 500)
+    return resp

--- a/bdauth/config.py
+++ b/bdauth/config.py
@@ -4,14 +4,18 @@ import os
 class Config():
     DEBUG = os.getenv('FLASK_DEBUG', default=False)
     ENV = os.getenv('FLASK_ENV', default='production')
+    SECRET_KEY = os.getenv('SECRET_KEY')
 
 
 class DevelopmentConfig(Config):
     DEBUG = True
     ENV = 'development'
+    SECRET_KEY = 'devsecrets'
 
 
 class TestingConfig(Config):
-    DEBUG = True
     TESTING = True
+
+    DEBUG = True
     ENV = 'testing'
+    SECRET_KEY = 'testing'

--- a/bdauth/debug.py
+++ b/bdauth/debug.py
@@ -1,0 +1,12 @@
+from flask import Blueprint, current_app, render_template
+
+from bdauth.auth import login_required
+
+
+bp = Blueprint('debug', __name__, url_prefix='/debug')
+
+
+@bp.route("/")
+@login_required
+def item(item="None"):
+    return 'debug'

--- a/saml/settings.json
+++ b/saml/settings.json
@@ -1,0 +1,28 @@
+{
+  "strict": true,
+  "debug": "",
+  "sp": {
+    "entityId": "",
+    "assertionConsumerService": {
+      "url": "",
+      "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    },
+    "x509cert": "",
+    "privateKey": ""
+  },
+  "idp": {
+    "entityId": "",
+    "singleSignOnService": {
+      "url": "",
+      "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    },
+    "x509cert": ""
+  },
+  "security": {
+    "requestedAuthnContext": false,
+    "signMetadata": true,
+    "authnRequestsSigned": true,
+    "wantAssertionsEncrypted": true,
+    "wantAssertionsSigned": true
+  }
+}


### PR DESCRIPTION
NOTE: the best place to see this in action is https://bd-auth-stage.mit.edu/debug

You will be prompted to Touchstone auth, then taken to a screen that says "debug" and nothing else.

This demonstrates we can protect app routes with Touchstone and return the initial route when authentication is successful.


Why are these changes being introduced:

* includes the SAML library we use for python apps to authenticate with
  Touchstone
* The SAML SP needs to be configured to the specifications of the
  Touchstone service

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2149

How does this address that need:

* Installs python library
* installs `libxmlsec1` in CI
* adds Apt build back and installs `libxmlsec1` in Heroku
* This provides a skeletal SAML SP that can provide the SP metadata
  required to proceed with the IST Touchstone registration
* A /debug SAML protected route is included to confirm successful SP
  registration



#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?

YES