### PR TITLE
Initial business logic for handling openurls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,30 @@
 - `python3-saml` package requires `libxmlsec1`.
   Suggest `brew install libxmlsec1` on macOS
 - possibly also needs `pkg-config` (not sure)
+- authentication is bypassed in development and testing environments. set `FAKE_USER` to what you want to simulate.
 
 ## Required ENV in production
 
+`BD_URL` = the borrowdirect URL
+
 `FLASK_APP` = bdauth
+
 `FLASK_ENV` = production
+
 `IDP_CERT` = standard IST IDP setting
+
 `IDP_ENTITY_ID` = standard IST IDP setting
+
 `IDP_SSO_URL` = standard IST IDP setting
+
 `SECRET_KEY` = generate a long random string. Used for session security
+
 `SP_ACS_URL` = route in this app that handles the response from IDP
+
 `SP_CERT` = obtained from self signed cert generated for this app
+
 `SP_ENTITY_ID` = domain name of app + /saml
+
 `SP_KEY` = obtained from self signed key generated for this app
+
+`URN_UID` = the key in the SAML response to pull the kerberos ID

--- a/bdauth/__init__.py
+++ b/bdauth/__init__.py
@@ -3,12 +3,12 @@ import os
 
 from flask import Flask
 
-from bdauth import auth, debug
-from bdauth.auth import login_required
+from bdauth import auth, debug, openurl
 
 app = Flask(__name__, instance_relative_config=True)
 app.register_blueprint(auth.bp)
 app.register_blueprint(debug.bp)
+app.register_blueprint(openurl.bp)
 
 flask_env = os.getenv('FLASK_ENV')
 

--- a/bdauth/config.py
+++ b/bdauth/config.py
@@ -5,12 +5,16 @@ class Config():
     DEBUG = os.getenv('FLASK_DEBUG', default=False)
     ENV = os.getenv('FLASK_ENV', default='production')
     SECRET_KEY = os.getenv('SECRET_KEY')
+    BD_URL = os.getenv('BD_URL')
+    URN_UID = os.getenv('URN_UID')
 
 
 class DevelopmentConfig(Config):
     DEBUG = True
     ENV = 'development'
     SECRET_KEY = 'devsecrets'
+    BD_URL = os.getenv('BD_URL')
+    FAKE_USER = os.getenv('FAKE_USER')
 
 
 class TestingConfig(Config):
@@ -19,3 +23,5 @@ class TestingConfig(Config):
     DEBUG = True
     ENV = 'testing'
     SECRET_KEY = 'testing'
+    BD_URL = 'http://example.com/?LS=XYZ'
+    FAKE_USER = 'yo@example.com'

--- a/bdauth/debug.py
+++ b/bdauth/debug.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, current_app, render_template
+from flask import Blueprint
+from flask.globals import session
 
 from bdauth.auth import login_required
 
@@ -9,4 +10,5 @@ bp = Blueprint('debug', __name__, url_prefix='/debug')
 @bp.route("/")
 @login_required
 def item(item="None"):
-    return 'debug'
+
+    return session['samlKerbid']

--- a/bdauth/openurl.py
+++ b/bdauth/openurl.py
@@ -1,0 +1,82 @@
+import urllib.parse
+
+from flask import Blueprint, redirect, request, session
+from flask.globals import current_app
+
+from bdauth.auth import login_required
+
+bp = Blueprint('openurl', __name__, url_prefix='/openurl')
+
+
+@bp.route("/")
+@login_required
+def construct_url():
+    bdurl = current_app.config['BD_URL']
+
+    code = 307
+    url = bdurl + pi_encryptor() + "&query=" + query_formatter(request.args)
+    return redirect(url, code)
+
+
+def pi_encryptor():
+    # currently passes through with no encryption
+    return '&PI=' + session['samlKerbid']
+
+
+def query_formatter(args):
+    bdquery = ""
+    joiner = ""
+
+    # current prod logic seems to be:
+    # if isbn
+    #   use isbn and nothing else
+    # else if any of the 4 titles exist:
+    #   use the title that exits in this preferential order
+    #      title, btitle, ctitle, jtitle
+    #      nested condition of if aulast include that as well
+
+    isbn = args.get('rft.isbn')
+    if isbn:
+        bdquery += "isbn=\"" + isbn + "\""
+        return urllib.parse.quote(bdquery)
+
+    aulast = args.get('rft.aulast')
+
+    title = args.get('rft.title')
+    if title:
+        bdquery += "ti=\"" + title + "\""
+        joiner = " and "
+        if aulast:
+            bdquery += joiner + "au=\"" + aulast + "\""
+
+        return urllib.parse.quote(bdquery)
+
+    title = args.get('rft.btitle')
+    if title:
+        bdquery += "ti=\"" + title + "\""
+        joiner = " and "
+        if aulast:
+            bdquery += joiner + "au=\"" + aulast + "\""
+
+        return urllib.parse.quote(bdquery)
+
+    title = args.get('rft.ctitle')
+    if title:
+        bdquery += "ti=\"" + title + "\""
+        joiner = " and "
+        if aulast:
+            bdquery += joiner + "au=\"" + aulast + "\""
+
+        return urllib.parse.quote(bdquery)
+
+    title = args.get('rft.jtitle')
+    if title:
+        bdquery += "ti=\"" + title + "\""
+        joiner = " and "
+        if aulast:
+            bdquery += joiner + "au=\"" + aulast + "\""
+
+        return urllib.parse.quote(bdquery)
+
+    # if nothing matches, just return. no search will be done
+    return ''

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings

--- a/tests/test_openurls.py
+++ b/tests/test_openurls.py
@@ -1,0 +1,120 @@
+import os
+import pytest
+import bdauth
+
+
+@pytest.fixture
+def client():
+    os.environ['FLASK_ENV'] = 'testing'
+    with bdauth.app.test_client() as client:
+        yield client
+
+
+def test_isbn(client):
+    response = client.get('/openurl/?rft.isbn=978-3-16-148410-0')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=isbn%3D%22978-3-16-148410-0%22'
+    assert response.headers['location'] == expected
+
+
+def test_title_no_author(client):
+    response = client.get('/openurl/?rft.title=title')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22'
+    assert response.headers['location'] == expected
+
+
+def test_title_with_author(client):
+    response = client.get('/openurl/?rft.title=title&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_btitle_no_author(client):
+    response = client.get('/openurl/?rft.btitle=title')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22'
+    assert response.headers['location'] == expected
+
+
+def test_btitle_with_author(client):
+    response = client.get('/openurl/?rft.btitle=title&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_ctitle_no_author(client):
+    response = client.get('/openurl/?rft.btitle=title')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22'
+    assert response.headers['location'] == expected
+
+
+def test_ctitle_with_author(client):
+    response = client.get('/openurl/?rft.btitle=title&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_jtitle_no_author(client):
+    response = client.get('/openurl/?rft.btitle=title')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22'
+    assert response.headers['location'] == expected
+
+
+def test_jtitle_with_author(client):
+    response = client.get('/openurl/?rft.btitle=title&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_no_rft_fields_of_interest(client):
+    response = client.get('/openurl/?rft.popcorn=soup')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query='
+    assert response.headers['location'] == expected
+
+
+def test_title_priority(client):
+    response = client.get(
+        '/openurl/?rft.title=title&rft.btitle=btitle&rft.ctitle=ctitle&rft.jtitle=jtitle&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22title%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_btitle_priority(client):
+    response = client.get(
+        '/openurl/?rft.btitle=btitle&rft.ctitle=ctitle&rft.jtitle=jtitle&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22btitle%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_ctitle_priority(client):
+    response = client.get(
+        '/openurl/?rft.ctitle=ctitle&rft.jtitle=jtitle&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22ctitle%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_jtitle_priority(client):
+    response = client.get(
+        '/openurl/?rft.jtitle=jtitle&rft.aulast=last')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=ti%3D%22jtitle%22%20and%20au%3D%22last%22'
+    assert response.headers['location'] == expected
+
+
+def test_fields_of_no_interest_ignored(client):
+    response = client.get(
+        '/openurl/?rft.isbn=978-3-16-148410-0&rft.popcorn=soup')
+    assert response.status_code == 307
+    expected = 'http://example.com/?LS=XYZ&PI=yo@example.com&query=isbn%3D%22978-3-16-148410-0%22'
+    assert response.headers['location'] == expected


### PR DESCRIPTION
Why are these changes being introduced:

* We need to implement the business logic to send the correct query to
  borrowdirect based on the incoming openurl (rft) parameters
* We need to send the authenticated user info to borrowdirect

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2152

How does this address that need:

* This is the initial work to handle the various incoming parameters
  and selectively send some along to the upstream service
* Currently passed through kerbid for testing purposes. Remaining work
  to encrypt this is necessary before it will work in production but the
  test bd service doesn't work with encrypted kerb (yet?)

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [x] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?

NO
