### PR TITLE
Encrypts PI sent to borrowdirect

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 flask = "*"
 gunicorn = "*"
 python3-saml = "*"
+pycryptodome = "*"
 
 [dev-packages]
 python-dotenv = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "448244710cbf3ea9a3390ba7d53a68f47266c503d8035f4fc683338271bae921"
+            "sha256": "ce5d463cbac46f7932d09085e5d57ad7434d4488bccd695b7356a58cb7f0ea6d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -162,6 +162,42 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
+        },
+        "pycryptodome": {
+            "hashes": [
+                "sha256:09c1555a3fa450e7eaca41ea11cd00afe7c91fef52353488e65663777d8524e0",
+                "sha256:12222a5edc9ca4a29de15fbd5339099c4c26c56e13c2ceddf0b920794f26165d",
+                "sha256:1723ebee5561628ce96748501cdaa7afaa67329d753933296321f0be55358dce",
+                "sha256:1c5e1ca507de2ad93474be5cfe2bfa76b7cf039a1a32fc196f40935944871a06",
+                "sha256:2603c98ae04aac675fefcf71a6c87dc4bb74a75e9071ae3923bbc91a59f08d35",
+                "sha256:2dea65df54349cdfa43d6b2e8edb83f5f8d6861e5cf7b1fbc3e34c5694c85e27",
+                "sha256:31c1df17b3dc5f39600a4057d7db53ac372f492c955b9b75dd439f5d8b460129",
+                "sha256:38661348ecb71476037f1e1f553159b80d256c00f6c0b00502acac891f7116d9",
+                "sha256:3e2e3a06580c5f190df843cdb90ea28d61099cf4924334d5297a995de68e4673",
+                "sha256:3f840c49d38986f6e17dbc0673d37947c88bc9d2d9dba1c01b979b36f8447db1",
+                "sha256:501ab36aae360e31d0ec370cf5ce8ace6cb4112060d099b993bc02b36ac83fb6",
+                "sha256:60386d1d4cfaad299803b45a5bc2089696eaf6cdd56f9fc17479a6f89595cfc8",
+                "sha256:6260e24d41149268122dd39d4ebd5941e9d107f49463f7e071fd397e29923b0c",
+                "sha256:6bbf7fee7b7948b29d7e71fcacf48bac0c57fb41332007061a933f2d996f9713",
+                "sha256:6d2df5223b12437e644ce0a3be7809471ffa71de44ccd28b02180401982594a6",
+                "sha256:758949ca62690b1540dfb24ad773c6da9cd0e425189e83e39c038bbd52b8e438",
+                "sha256:77997519d8eb8a4adcd9a47b9cec18f9b323e296986528186c0e9a7a15d6a07e",
+                "sha256:7fd519b89585abf57bf47d90166903ec7b43af4fe23c92273ea09e6336af5c07",
+                "sha256:98213ac2b18dc1969a47bc65a79a8fca02a414249d0c8635abb081c7f38c91b6",
+                "sha256:99b2f3fc51d308286071d0953f92055504a6ffe829a832a9fc7a04318a7683dd",
+                "sha256:9b6f711b25e01931f1c61ce0115245a23cdc8b80bf8539ac0363bdcf27d649b6",
+                "sha256:a3105a0eb63eacf98c2ecb0eb4aa03f77f40fbac2bdde22020bb8a536b226bb8",
+                "sha256:a8eb8b6ea09ec1c2535bf39914377bc8abcab2c7d30fa9225eb4fe412024e427",
+                "sha256:a92d5c414e8ee1249e850789052608f582416e82422502dc0ac8c577808a9067",
+                "sha256:d3d6958d53ad307df5e8469cc44474a75393a434addf20ecd451f38a72fe29b8",
+                "sha256:e0a4d5933a88a2c98bbe19c0c722f5483dc628d7a38338ac2cb64a7dbd34064b",
+                "sha256:e3bf558c6aeb49afa9f0c06cee7fb5947ee5a1ff3bd794b653d39926b49077fa",
+                "sha256:e61e363d9a5d7916f3a4ce984a929514c0df3daf3b1b2eb5e6edbb131ee771cf",
+                "sha256:f977cdf725b20f6b8229b0c87acb98c7717e742ef9f46b113985303ae12a99da",
+                "sha256:fc7489a50323a0df02378bc2fff86eb69d94cc5639914346c736be981c6a02e7"
+            ],
+            "index": "pypi",
+            "version": "==3.10.1"
         },
         "python3-saml": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 ## Required ENV in production
 
+`BD_KEY` = the supplied public key, base64encoded, for borrowdirect
+
 `BD_URL` = the borrowdirect URL
 
 `FLASK_APP` = bdauth

--- a/bdauth/config.py
+++ b/bdauth/config.py
@@ -5,6 +5,7 @@ class Config():
     DEBUG = os.getenv('FLASK_DEBUG', default=False)
     ENV = os.getenv('FLASK_ENV', default='production')
     SECRET_KEY = os.getenv('SECRET_KEY')
+    BD_KEY = os.getenv('BD_KEY')
     BD_URL = os.getenv('BD_URL')
     URN_UID = os.getenv('URN_UID')
 
@@ -13,6 +14,7 @@ class DevelopmentConfig(Config):
     DEBUG = True
     ENV = 'development'
     SECRET_KEY = 'devsecrets'
+    BD_KEY = os.getenv('BD_KEY')
     BD_URL = os.getenv('BD_URL')
     FAKE_USER = os.getenv('FAKE_USER')
 


### PR DESCRIPTION
Why are these changes being introduced:

* borrowdirect is configured to expected us to send an encrypted
  parameter that includes a user identifier and a timestamp

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2151

How does this address that need:

* Re-implments the logic from our legacy perl scripts to construct the
  expected data

Document any side effects to this change:

- the tests bypass the encryption for simplicity, but that means the
  encrypted logic is only validated through acceptance testing and not
  unit testing

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?

YES
