### PR TITLE
Force SSL for production environments

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ gunicorn = "*"
 python3-saml = "*"
 pycryptodome = "*"
 sentry-sdk = {extras = ["flask"], version = "*"}
+flask-talisman = "*"
 
 [dev-packages]
 python-dotenv = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f36fac4bae2fbe9e942ea1b661f698b5bf675ef698b71bc16ff692b0d105ab59"
+            "sha256": "0be079ecbd7f7921ba74cd8fe212689f840623d8ad04a9883576d0e6fc471829"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -52,6 +52,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.1"
+        },
+        "flask-talisman": {
+            "hashes": [
+                "sha256:08a25360c771f7a79d6d4db2abfa71f7422e62a714418b671d69d6a201764d05",
+                "sha256:5d502ec0c51bf1755a797b8cffbe4e94f8684af712ba0b56f3d80b79277ef285"
+            ],
+            "index": "pypi",
+            "version": "==0.8.1"
         },
         "gunicorn": {
             "hashes": [
@@ -242,11 +250,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         },
         "werkzeug": {
             "hashes": [

--- a/bdauth/__init__.py
+++ b/bdauth/__init__.py
@@ -1,7 +1,8 @@
 import logging
 import os
 
-from flask import Flask
+from flask import Flask, redirect
+from flask_talisman import Talisman
 
 from bdauth import auth, debug, openurl
 
@@ -18,6 +19,7 @@ app = Flask(__name__, instance_relative_config=True)
 app.register_blueprint(auth.bp)
 app.register_blueprint(debug.bp)
 app.register_blueprint(openurl.bp)
+Talisman(app)
 
 flask_env = os.getenv('FLASK_ENV')
 
@@ -34,7 +36,7 @@ logging.basicConfig(level=logging.INFO)
 
 @app.route('/')
 def root():
-    return 'Hallo!'
+    return redirect('https://libraries.mit.edu/borrow/borrowdirect/', 307)
 
 
 @app.route('/ping')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -18,4 +18,6 @@ def test_ping(client):
 
 def test_root(client):
     res = client.get('/')
-    assert res.status_code == 200
+    assert res.status_code == 307
+    expected = 'https://libraries.mit.edu/borrow/borrowdirect/'
+    assert res.headers['location'] == expected


### PR DESCRIPTION
Why are these changes being introduced:

* SSL good

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2185

How does this address that need:

* Uses Flask-Talisman as recommended in current Flask documentation
  https://flask.palletsprojects.com/en/2.0.x/security/#security-headers

Document any side effects to this change:

* Changed default route to point to a page that explains BorrowDirect

#### Developer

- [x] All new ENV is documented in README
- [x] All new ENV has been added to Heroku Pipeline, Staging and Prod
- [ ] Stakeholder approval has been confirmed (or is not needed)

#### Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] There are appropriate tests covering any new functionality
- [x] The documentation has been updated or is unnecessary
- [x] The changes have been verified
- [x] New dependencies are appropriate or there were no changes

#### Includes new or updated dependencies?

YES
